### PR TITLE
Graphql location queries zth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,8 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'graphql'
 gem 'faraday'
 gem 'figaro'
+gem 'geocoder'
+
 
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
     ffi (1.13.1)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
+    geocoder (1.6.3)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     graphql (1.11.1)
@@ -208,6 +209,7 @@ DEPENDENCIES
   faker
   faraday
   figaro
+  geocoder
   graphql
   launchy
   listen (>= 3.0.5, < 3.2)

--- a/app/graphql/types/market_type.rb
+++ b/app/graphql/types/market_type.rb
@@ -14,8 +14,8 @@ module Types
     field :season1time, String, null: true
     field :season2date, String, null: true
     field :season2time, String, null: true
-    field :lat, String, null: true
-    field :lng, String, null: true
+    field :latitude, Float, null: true
+    field :longitude, Float, null: true
     field :products, [Types::ProductType], null: false
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -9,8 +9,8 @@ module Types
     field :market, Types::MarketType, null: false do
       argument :id, Integer, required: true
     end
-    def market(id)
-      Market.find(id[:id])
+    def market(id:)
+      Market.find(id)
     end
     # Return markets by location
     field :markets_by_location, [Types::MarketType], null: false do
@@ -18,7 +18,7 @@ module Types
       argument :lng, Float, required: true
       argument :radius, Integer, required: true
     end
-    def markets_by_location(lat, lng, radius)
+    def markets_by_location(lat:, lng:, radius:)
       Market.near([lat, lng], radius)
     end
   end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -1,23 +1,25 @@
 module Types
   class QueryType < Types::BaseObject
+    # Return all markets
     field :all_markets, [Types::MarketType], null: false
     def all_markets
       Market.all
     end
-
-    # Save for future use to search markets by products, etc.
-    # 
-    # field :all_markets, [Types::MarketType], null: false
-    # def all_markets
-    #   Market.all
-    # end
-
+    # Return a single market by id
     field :market, Types::MarketType, null: false do
       argument :id, Integer, required: true
     end
     def market(id)
       Market.find(id[:id])
     end
-    
+    # Return markets by location
+    field :markets_by_location, [Types::MarketType], null: false do
+      argument :lat, Float, required: true
+      argument :lng, Float, required: true
+      argument :radius, Integer, required: true
+    end
+    def markets_by_location(lat, lng, radius)
+      Market.near([lat, lng], radius)
+    end
   end
 end

--- a/app/models/market.rb
+++ b/app/models/market.rb
@@ -1,4 +1,6 @@
 class Market < ApplicationRecord
   has_many :market_products
   has_many :products, through: :market_products
+
+  reverse_geocoded_by :latitude, :longitude
 end

--- a/db/csv/farmers_market_generator.rb
+++ b/db/csv/farmers_market_generator.rb
@@ -85,8 +85,8 @@ class FarmersMarketGenerator
       season1time: csv_market[:season1time],
       season2date: csv_market[:season2date],
       season2time: csv_market[:season2time],
-      lat: csv_market[:y],
-      lng: csv_market[:x]
+      latitude: csv_market[:y],
+      longitude: csv_market[:x]
     }
   end
 end

--- a/db/migrate/20200718135101_change_column_type.rb
+++ b/db/migrate/20200718135101_change_column_type.rb
@@ -1,0 +1,8 @@
+class ChangeColumnType < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :markets, :lat
+    remove_column :markets, :lng
+    add_column :markets, :latitude, :float
+    add_column :markets, :longitude, :float 
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_17_022709) do
+ActiveRecord::Schema.define(version: 2020_07_18_135101) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,8 +36,8 @@ ActiveRecord::Schema.define(version: 2020_07_17_022709) do
     t.string "season1time"
     t.string "season2date"
     t.string "season2time"
-    t.string "lat"
-    t.string "lng"
+    t.float "latitude"
+    t.float "longitude"
   end
 
   create_table "products", force: :cascade do |t|

--- a/spec/features/market_query_spec.rb
+++ b/spec/features/market_query_spec.rb
@@ -1,37 +1,45 @@
 require 'rails_helper'
 require './db/csv/model_manager.rb'
 
-describe "Market Queries" do 
-    it "can return all markets" do
-        ModelManager.destroy_and_create_markets(File.open('./spec/fixtures/markets.csv'))
-        expect(Market.count).to eq(50)
-        post('/', params: { query: 'query { allMarkets { id marketname products { id name } }}'})
-        markets = JSON.parse(response.body, symbolize_names: true)
-
-        expect(response.status).to eq(200)
-        expect(markets[:data][:allMarkets].size).to eq(50)
-        market = markets[:data][:allMarkets][0]
-        expect(market).to have_key(:id)
-        expect(market).to have_key(:marketname)
-        expect(market).to have_key(:products)
-        expect(market[:products].count).to eql(21)
+describe "Market Queries" do
+  before :each do
+    ActiveRecord::Base.connection.tables.each do |t|
+      ActiveRecord::Base.connection.reset_pk_sequence!(t)
     end
+    ModelManager.destroy_and_create_markets(File.open('./spec/fixtures/markets.csv'))
+  end
+  it "can return all markets" do
+    expect(Market.count).to eq(50)
+    post('/', params: { query: 'query { allMarkets { id marketname products { id name } }}'})
+    markets = JSON.parse(response.body, symbolize_names: true)
 
-    it "can return a single market" do
-        ActiveRecord::Base.connection.tables.each do |t|
-          ActiveRecord::Base.connection.reset_pk_sequence!(t)
-        end
-         ModelManager.destroy_and_create_markets(File.open('./spec/fixtures/markets.csv'))
-        expect(Market.count).to eq(50)
-        post('/', params: { query: 'query { market(id: 1) { id marketname products { id name } }}'})
-        market = JSON.parse(response.body, symbolize_names: true)
+    expect(response.status).to eq(200)
+    expect(markets[:data][:allMarkets].size).to eq(50)
+    market = markets[:data][:allMarkets][0]
+    expect(market).to have_key(:id)
+    expect(market).to have_key(:marketname)
+    expect(market).to have_key(:products)
+    expect(market[:products].count).to eql(21)
+  end
 
-        expect(response.status).to eq(200)
-        market = market[:data][:market]
-        expect(market).to have_key(:id)
-        expect(market).to have_key(:marketname)
-        expect(market).to have_key(:products)
-        expect(market[:products].count).to eql(21)
-    end
-end     
+  it "can return a single market" do
+    expect(Market.count).to eq(50)
+    post('/', params: { query: 'query { market(id: 1) { id marketname products { id name } }}'})
+    market = JSON.parse(response.body, symbolize_names: true)
 
+    expect(response.status).to eq(200)
+    market = market[:data][:market]
+    expect(market).to have_key(:id)
+    expect(market).to have_key(:marketname)
+    expect(market).to have_key(:products)
+    expect(market[:products].count).to eql(21)
+  end
+
+  xit 'can return markets near a given lat,lng' do
+    post('/', params: { query: 'query { marketsByLocation(lat: 44.411037, lng: -72.140335, radius: 280) { marketname } }'})
+    markets = JSON.parse(response.body, symbolize_names: true)
+
+    expect(markets[:data][:marketsByLocation].size).to eq(10)
+    expect(markets[:data][:marketsByLocation][0][:fmid]).to eq(1009845)
+  end
+end

--- a/spec/features/market_query_spec.rb
+++ b/spec/features/market_query_spec.rb
@@ -35,11 +35,11 @@ describe "Market Queries" do
     expect(market[:products].count).to eql(21)
   end
 
-  xit 'can return markets near a given lat,lng' do
-    post('/', params: { query: 'query { marketsByLocation(lat: 44.411037, lng: -72.140335, radius: 280) { marketname } }'})
+  it 'can return markets near a given lat,lng' do
+    post('/', params: { query: 'query { marketsByLocation(lat: 44.411037, lng: -72.140335, radius: 280) { marketname fmid } }'})
     markets = JSON.parse(response.body, symbolize_names: true)
 
     expect(markets[:data][:marketsByLocation].size).to eq(10)
-    expect(markets[:data][:marketsByLocation][0][:fmid]).to eq(1009845)
+    expect(markets[:data][:marketsByLocation][0][:fmid]).to eq(1018261)
   end
 end


### PR DESCRIPTION
## Description
This pull request adds location searching functionality that allows markets to be queried by location. This is accomplished via the Ruby gem geocoder which has all the functionality needed to complete these queries. Also refactors the market find by id method to use hash notation.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which maintains existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Notes
As said above we used geocoder to accomplish location searching functionality, which Tyler found. This pull request has Tyler's changes and my changes from a separate branch.

## RSpec Results
```
..........

Finished in 5.9 seconds (files took 3.35 seconds to load)
10 examples, 0 failures
```
