### PR TITLE
Graphql interface setup zth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem "graphiql-rails"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,9 @@ GEM
     geocoder (1.6.3)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    graphiql-rails (1.7.0)
+      railties
+      sprockets-rails
     graphql (1.11.1)
     hashdiff (1.0.1)
     i18n (1.8.3)
@@ -210,6 +213,7 @@ DEPENDENCIES
   faraday
   figaro
   geocoder
+  graphiql-rails
   graphql
   launchy
   listen (>= 3.0.5, < 3.2)

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,0 +1,2 @@
+//= link graphiql/rails/application.css
+//= link graphiql/rails/application.js

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,7 @@ require "action_controller/railtie"
 # require "action_mailer/railtie"
 require "action_view/railtie"
 # require "action_cable/engine"
-# require "sprockets/railtie"
+require "sprockets/railtie"
 require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,4 @@ Rails.application.routes.draw do
     mount GraphiQL::Rails::Engine, at: "/graphiql", graphql_path: "graphql#execute"
     post "/graphql", to: "graphql#execute"
   end
-
-  
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,10 @@
 Rails.application.routes.draw do
-  post "/", to: "graphql#execute"
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  post '/', to: 'graphql#execute'
+  # graphQL IDE
+  if Rails.env.development?
+    mount GraphiQL::Rails::Engine, at: "/graphiql", graphql_path: "graphql#execute"
+    post "/graphql", to: "graphql#execute"
+  end
+
+  
 end


### PR DESCRIPTION
## Description
Sets up graph QL IDE to be used on localhost:3000/graphiql
Makes it dynamic so we can still use '/' endpoint in production/test environments if we want to

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Notes
You'll need to bundle install when pulling this down. To use interface start `rails s` and visit '/graphiql'

## RSpec Results
```
..........

Finished in 5.28 seconds (files took 3.53 seconds to load)
10 examples, 0 failures

```
