### PR TITLE
marketsByCity

### DIFF
--- a/app/graphql/types/return_type.rb
+++ b/app/graphql/types/return_type.rb
@@ -1,6 +1,8 @@
 module Types
   class ReturnType < Types::BaseObject
     field :markets, [Types::MarketType], null: false
-    field :location, String, null: false
+    field :location, String, null: true
+    field :latitude, Float, hash_key: 'latitude', null: true
+    field :longitude, Float, hash_key: 'longitude', null: true
   end
 end

--- a/spec/features/market_query_spec.rb
+++ b/spec/features/market_query_spec.rb
@@ -36,33 +36,50 @@ describe "Market Queries" do
   end
 
   it 'can return markets near a given lat,lng' do
-    post('/', params: { query: 'query { marketsByLocation(lat: 44.411037, lng: -72.140335, radius: 280) { markets { marketname fmid distance } } }'})
+    post('/', params: { query: 'query { marketsByCoords(lat: 44.411037, lng: -72.140335, radius: 280) { markets { marketname fmid distance } } }'})
     markets = JSON.parse(response.body, symbolize_names: true)
 
-    expect(markets[:data][:marketsByLocation][:markets].size).to eq(10)
-    expect(markets[:data][:marketsByLocation][:markets][0][:fmid]).to eq(1018261)
+    expect(markets[:data][:marketsByCoords][:markets].size).to eq(10)
+    expect(markets[:data][:marketsByCoords][:markets][0][:fmid]).to eq(1018261)
   end
 
   it 'can return markets distance away from a given lat, lng' do
-    post('/', params: { query: 'query { marketsByLocation(lat: 44.411037, lng: -72.140335, radius: 280) { markets { marketname fmid  distance } } }'})
+    post('/', params: { query: 'query { marketsByCoords(lat: 44.411037, lng: -72.140335, radius: 280) { markets { marketname fmid  distance } } }'})
     markets = JSON.parse(response.body, symbolize_names: true)
 
-    expect(markets[:data][:marketsByLocation][:markets][0][:distance]).to eq(0.0)
-    expect(markets[:data][:marketsByLocation][:markets].last[:distance].round(2)).to eq(268.62)
+    expect(markets[:data][:marketsByCoords][:markets][0][:distance]).to eq(0.0)
+    expect(markets[:data][:marketsByCoords][:markets].last[:distance].round(2)).to eq(268.62)
   end
   it 'can return city and state for given lat and lng' do
-    post('/', params: { query: 'query { marketsByLocation(lat: 44.411037, lng: -72.140335, radius: 280) { markets { marketname fmid distance } location } }'})
+    post('/', params: { query: 'query { marketsByCoords(lat: 44.411037, lng: -72.140335, radius: 280) { markets { marketname fmid distance } location } }'})
     markets = JSON.parse(response.body, symbolize_names: true)
 
-    expect(markets[:data][:marketsByLocation][:location]).to eq('Danville, Vermont')
+    expect(markets[:data][:marketsByCoords][:location]).to eq('Danville, Vermont')
   end
-  it 'can filter marketsByLocation by products' do
-    post('/', params: { query: 'query { marketsByLocation(lat: 44.411037, lng: -72.140335, radius: 280, products: ["bakedgoods", "fruits", "cheese", "flowers", "eggs", "seafood"]) { markets { marketname fmid distance products { name } } } }'})
+  it 'can filter marketsByCoords by products' do
+    post('/', params: { query: 'query { marketsByCoords(lat: 44.411037, lng: -72.140335, radius: 280, products: ["bakedgoods", "fruits", "cheese", "flowers", "eggs", "seafood"]) { markets { marketname fmid distance products { name } } } }'})
     markets = JSON.parse(response.body, symbolize_names: true)
 
-    expect(markets[:data][:marketsByLocation][:markets].size).to eq(2)
-    expect(markets[:data][:marketsByLocation][:markets].first[:fmid]).to eq(1016782)
-    expect(markets[:data][:marketsByLocation][:markets].last[:fmid]).to eq(1000061)
-    expect(markets[:data][:marketsByLocation][:markets].sample[:products].map(&:values).flatten).to include("bakedgoods", "fruits", "cheese", "flowers", "eggs", "seafood")
+    expect(markets[:data][:marketsByCoords][:markets].size).to eq(2)
+    expect(markets[:data][:marketsByCoords][:markets].first[:fmid]).to eq(1016782)
+    expect(markets[:data][:marketsByCoords][:markets].last[:fmid]).to eq(1000061)
+    expect(markets[:data][:marketsByCoords][:markets].sample[:products].map(&:values).flatten).to include("bakedgoods", "fruits", "cheese", "flowers", "eggs", "seafood")
+  end
+  it 'can return markets near a given city, state' do
+    post('/', params: { query: 'query { marketsByCity(city: "Dayton", state: "Ohio", radius: 200) { markets { marketname distance } latitude longitude } }'})
+    markets = JSON.parse(response.body, symbolize_names: true)
+
+    expect(markets[:data][:marketsByCity][:markets].size).to eq(4)
+    expect(markets[:data][:marketsByCity][:markets].first[:marketname]).to eq("2nd Street Market - Five Rivers MetroPark")
+    expect(markets[:data][:marketsByCity][:latitude]).to eq(39.7589478)
+    expect(markets[:data][:marketsByCity][:longitude]).to eq(-84.1916069)
+  end
+  it 'can filterMarketsByCity by products' do
+    post('/', params: { query: 'query { marketsByCity(city: "Dayton", state: "Ohio", radius: 200, products: ["bakedgoods", "fruits"]) { markets { marketname products { name } } } }'})
+    markets = JSON.parse(response.body, symbolize_names: true)
+
+    expect(markets[:data][:marketsByCity][:markets].size).to eq(3)
+    expect(markets[:data][:marketsByCity][:markets].first[:marketname]).to eq("2nd Street Market - Five Rivers MetroPark")
+    expect(markets[:data][:marketsByCity][:markets].sample[:products].map(&:values).flatten).to include("bakedgoods", "fruits")
   end
 end


### PR DESCRIPTION
## Description
* Renames `marketsByLocation` to `marketsByCoords`
* Creates `marketsByCity` query that takes a `city, state` instead of `[lat, lng]` 
## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Notes
* Example request: 
```
query {
  marketsByCity(city: "Dayton", 
                    state: "Ohio", 
                    radius: 200, 
                    products: ["bakedgoods", "fruits"]) {
    markets {
      marketname  products { name }
    }
    latitude 
    longitude
  }
}
```
* Example response:
```
{:data=>
  {:marketsByCity=>
    {:markets=>
      [{:marketname=>"175th Street Greenmarket",
          :products=>[{:name=>"bakedgoods"}, {:name=>"cheese"}, {:name=>"flowers"}, {:name=>"eggs"}, 
            {:name=>"seafood"}, 
            {:name=>"herbs"}, {:name=>"vegetables"}, {:name=>"honey"}, {:name=>"jams"}, {:name=>"fruits"}, 
            {:name=>"grains"}, 
            {:name=>"juices"}]},
       {:marketname=>"79th Street Greenmarket",
          :products=>
           [{:name=>"bakedgoods"},
            {:name=>"cheese"},
            {:name=>"flowers"},
            {:name=>"eggs"},
            {:name=>"seafood"},
            {:name=>"herbs"},
            {:name=>"vegetables"},
            {:name=>"honey"},
            {:name=>"jams"},
            {:name=>"maple"},
            {:name=>"meat"},
            {:name=>"plants"},
            {:name=>"poultry"},
            {:name=>"prepared"},
            {:name=>"fruits"}]}]}}}
``` 
## RSpec Results
```
...............

Finished in 15.9 seconds (files took 2.91 seconds to load)
15 examples, 0 failures

Coverage report generated for RSpec to /Users/tylerporter/Turing/mod4/us_farmers_markets_api/coverage. 261 / 273 LOC (95.6%) covered.
```
