### PR TITLE
Season Dates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ addons:
   chrome: stable
 dist: xenial
 before_install:
-  - export TZ=Mountain/Standard
   - yes | gem update --system --force
   - gem install bundler
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
   chrome: stable
 dist: xenial
 before_install:
+  - export TZ=Mountain/Standard
   - yes | gem update --system --force
   - gem install bundler
 script:

--- a/app/graphql/types/market_type.rb
+++ b/app/graphql/types/market_type.rb
@@ -18,6 +18,7 @@ module Types
     field :longitude, Float, null: true
     field :products, [Types::ProductType], null: false
     field :distance, Float, null: true
-    field :closest_date, String, null: true 
+    field :closest_date, String, null: true
+    field :season_dates, String, null: false
   end
 end

--- a/app/models/market.rb
+++ b/app/models/market.rb
@@ -4,6 +4,8 @@ class Market < ApplicationRecord
 
   reverse_geocoded_by :latitude, :longitude
 
+  after_initialize :get_season_dates
+
   def self.order_by_closest_date(date)
     filtered = Market.all.reject do |market|
       market.season1date.nil? ||
@@ -15,7 +17,7 @@ class Market < ApplicationRecord
     filtered.each do |market|
       market.class_eval do
         attr_accessor :closest_date
-      end 
+      end
     end
     filtered.each { |market| market.closest_date = market.closest_date_formatted(date) }
     filtered.sort_by { |market| market.closest_date_obj(date) }
@@ -31,5 +33,33 @@ class Market < ApplicationRecord
 
   def closest_date_obj(date)
     MarketDate.new(self.season1date, self.season1time).find_closest(date)
+  end
+
+  private
+
+  def get_season_dates
+    self.class_eval do
+      attr_accessor :season_dates
+    end
+    if season1date.nil? || season1time.nil?
+      self.season_dates = "No dates provided for this market."
+    elsif ("0".."1").exclude?(season1date.first) ||
+    ("0".."1").exclude?(season1date.split(" ").last.first)
+      self.season_dates = "#{season1date}, #{season1time}"
+    else
+      self.season_dates =  "#{start_date} to #{end_date}, #{season1time}"
+    end
+  end
+
+  def start_date
+    date = season1date.split(" ").first
+    date[-4..-1] = Time.current.year.to_s
+    date
+  end
+
+  def end_date
+    date = season1date.split(" ").last
+    date[-4..-1] = Time.current.year.to_s
+    date
   end
 end

--- a/spec/features/market_query_spec.rb
+++ b/spec/features/market_query_spec.rb
@@ -113,7 +113,8 @@ describe "Market Queries" do
   it 'can return season dates for each market' do
     post('/', params: { query: 'query { marketsByDate(date: "8/01/2020") { marketname closestDate seasonDates } }'})
     markets = JSON.parse(response.body, symbolize_names: true)
+    market = markets[:data][:marketsByDate].find {|market| market[:marketname] == "61st Street Farmers Market"}
 
-    expect(markets[:data][:marketsByDate].first[:seasonDates]).to eq("05/12/2020 to 12/15/2020, Sat: 9:00 AM-2:00 PM;")
+    expect(market[:seasonDates]).to eq("05/12/2020 to 12/15/2020, Sat: 9:00 AM-2:00 PM;")
   end
 end

--- a/spec/features/market_query_spec.rb
+++ b/spec/features/market_query_spec.rb
@@ -110,4 +110,10 @@ describe "Market Queries" do
     expect(markets[:data][:marketsByCity][:markets][0][:distance].round(2)).to eq(170.59)
     expect(markets[:data][:marketsByCity][:markets][-1][:distance].round(2)).to eq(104.47)
   end
+  it 'can return season dates for each market' do
+    post('/', params: { query: 'query { marketsByDate(date: "8/01/2020") { marketname closestDate seasonDates } }'})
+    markets = JSON.parse(response.body, symbolize_names: true)
+
+    expect(markets[:data][:marketsByDate].first[:seasonDates]).to eq("05/12/2020 to 12/15/2020, Sat: 9:00 AM-2:00 PM;")
+  end
 end


### PR DESCRIPTION
## Description
* Adds `season_dates` attribute to markets after initialize
* Creates return attribute `seasonDates` for a market
## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Notes
* Instead of requesting `season1date1` and `season1time` for a market, request `seasonDates` for better formatting and more up to date information
## RSpec Results
```
...................

Finished in 22.97 seconds (files took 2 seconds to load)
19 examples, 0 failures

Coverage report generated for RSpec to /Users/tylerporter/Turing/mod4/us_farmers_markets_api/coverage. 362 / 375 LOC (96.53%) covered.
```
