### PR TITLE
Markets By Date Fix

### DIFF
--- a/app/models/market.rb
+++ b/app/models/market.rb
@@ -7,31 +7,22 @@ class Market < ApplicationRecord
   after_initialize :get_season_dates
 
   def self.order_by_closest_date(date)
-    filtered = Market.all.reject do |market|
+    Market.all.reject do |market|
       market.season1date.nil? ||
       market.season1time.nil? ||
       ("0".."1").exclude?(market.season1date.first) ||
       ("0".."1").exclude?(market.season1date.split(" ").last.first) ||
       market.season1date.split(" ").size == 1
-    end
-    filtered.each do |market|
-      market.class_eval do
-        attr_accessor :closest_date
-      end
-    end
-    filtered.each { |market| market.closest_date = market.closest_date_formatted(date) }
-    filtered = filtered.reject {|market| market.closest_date == 'None'}
-    filtered.sort_by { |market| market.closest_date_obj(date) }
+    end.reject do |market|
+      market.closest_date = market.closest_date_formatted(date)
+      market.closest_date == 'None'
+    end.sort_by { |market| market.closest_date_obj(date) }
   end
 
   def closest_date_formatted(date)
     date_obj = closest_date_obj(date)
     return 'None' if date_obj == 'None'
     date_obj.to_formatted_s(:long)
-  end
-
-  def market_dates
-    MarketDate.new(self.season1date, self.season1time).new.get_dates
   end
 
   def closest_date_obj(date)
@@ -43,6 +34,7 @@ class Market < ApplicationRecord
   def get_season_dates
     self.class_eval do
       attr_accessor :season_dates
+      attr_accessor :closest_date
     end
     if season1date.nil? || season1time.nil?
       self.season_dates = "No dates provided for this market."

--- a/app/models/market.rb
+++ b/app/models/market.rb
@@ -12,7 +12,7 @@ class Market < ApplicationRecord
       market.season1time.nil? ||
       ("0".."1").exclude?(market.season1date.first) ||
       ("0".."1").exclude?(market.season1date.split(" ").last.first) ||
-      market.closest_date_obj(date).nil?
+      market.season1date.split(" ").size == 1
     end
     filtered.each do |market|
       market.class_eval do
@@ -20,11 +20,14 @@ class Market < ApplicationRecord
       end
     end
     filtered.each { |market| market.closest_date = market.closest_date_formatted(date) }
+    filtered = filtered.reject {|market| market.closest_date == 'None'}
     filtered.sort_by { |market| market.closest_date_obj(date) }
   end
 
   def closest_date_formatted(date)
-    closest_date_obj(date).to_formatted_s(:long)
+    date_obj = closest_date_obj(date)
+    return 'None' if date_obj == 'None'
+    date_obj.to_formatted_s(:long)
   end
 
   def market_dates

--- a/app/poros/market_date.rb
+++ b/app/poros/market_date.rb
@@ -8,13 +8,21 @@ class MarketDate
   end
 
   def get_dates
-    (start_date..end_date).select do |date|
+    if day_started.to_time > day_ended.to_time
+      start_day, end_day = day_ended, day_started
+    else
+      start_day, end_day = day_started, day_ended
+    end
+    (start_day..end_day).select do |date|
       dow = day_of_week(date)
       date.public_send(dow) if dow != nil
     end
   end
 
   def find_closest(req_date)
+    if future_dates(req_date).empty?
+      return 'None'
+    end
     future_dates(req_date).sort_by do |date|
       date.to_time - date_obj(req_date).to_time
     end.first
@@ -42,15 +50,17 @@ class MarketDate
     @season1time.split(";").map { |times| times.split(":") }.map(&:first)
   end
 
-  def start_date
+  def day_started
     date= @season1date.split(" ").first
     date[-4..-1] = Time.current.year.to_s
+    date.gsub!("31", "30")
     date_obj(date)
   end
 
-  def end_date
+  def day_ended
     date = @season1date.split(" ").last
     date[-4..-1] = Time.current.year.to_s
+    date.gsub!("31", "30")
     date_obj(date)
   end
 end


### PR DESCRIPTION
## Description
* Accounts for poor `season1date` data collection
## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Notes
* The data set provided by USDA is out of date and riddled with errors. This PR accounts for those errors as to still be able to filter markets by date. 
## RSpec Results
```
...................

Finished in 22.91 seconds (files took 2.01 seconds to load)
19 examples, 0 failures

Coverage report generated for RSpec to /Users/tylerporter/Turing/mod4/us_farmers_markets_api/coverage. 369 / 381 LOC (96.85%) covered.
```
